### PR TITLE
Add support for custom game paths and remove an unnecessary dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vs
 bin
 obj
+GamePath.props

--- a/PoY-RoutingFlag.csproj
+++ b/PoY-RoutingFlag.csproj
@@ -51,12 +51,23 @@
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
 	</ItemGroup>
 
+	<Import Condition="Exists('GamePath.props')" Project="GamePath.props"/>
+
+	<PropertyGroup Condition="'$(GamePath)' == ''">
+		<GamePath Condition="'$(OS)' == 'Unix'">$(HOME)/.local/share/Steam/steamapps/common/Peaks of Yore</GamePath>
+		<GamePath Condition="'$(OS)' == 'Windows_NT'">C:/Program Files (x86)/Steam/steamapps/common/Peaks of Yore</GamePath>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<GameLibPath>$(GamePath)/Peaks of Yore_Data/Managed</GameLibPath>
+	</PropertyGroup>
+
 	<ItemGroup>
 	  <Reference Include="Assembly-CSharp">
-	    <HintPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\Peaks of Yore_Data\Managed\Assembly-CSharp.dll</HintPath>
+	    <HintPath>$(GameLibPath)\Assembly-CSharp.dll</HintPath>
 	  </Reference>
 	  <Reference Include="Rewired_Core">
-	    <HintPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\Peaks of Yore_Data\Managed\Rewired_Core.dll</HintPath>
+	    <HintPath>$(GameLibPath)\Rewired_Core.dll</HintPath>
 	  </Reference>
 	</ItemGroup>
 

--- a/PoY-RoutingFlag.csproj
+++ b/PoY-RoutingFlag.csproj
@@ -35,7 +35,6 @@
 	<ItemGroup Condition="$(Configuration.EndsWith('-BepInEx'))">
 		<PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
 		<PackageReference Include="BepInEx.Core" Version="5.*" />
-		<PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(Configuration.EndsWith('-MelonLoader'))">


### PR DESCRIPTION
- Creating a file called GamePath.props with the following contents (as an example) allows custom paths to references:
```xml
<Project>
  <PropertyGroup>
    <GamePath>F:/Steam/steamapps/common/Peaks of Yore</GamePath>
  </PropertyGroup>
</Project>
```
- BepInEx.PluginInfoProps is unneeded as PluginInfo.cs is written to before compiling.